### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/sequential/sequential_include.rb
+++ b/lib/sequential/sequential_include.rb
@@ -1,5 +1,5 @@
 require 'active_support/core_ext/hash/slice'
-require 'active_support/core_ext/class/attribute_accessors'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module Sequential
   module SequentialInclude


### PR DESCRIPTION
This fixes a warning caused by a new Rails version:

DEPRECATION WARNING: The cattr_\* method definitions have been moved into active_support/core_ext/module/attribute_accessors. 
