### PR TITLE
add support for use_sti_base_class option

### DIFF
--- a/lib/sequential/generator.rb
+++ b/lib/sequential/generator.rb
@@ -1,19 +1,20 @@
 module Sequential
   class Generator
-    attr_reader :record, :scope, :column, :start_at, :skip
+    attr_reader :record, :scope, :column, :start_at, :skip, :use_sti_base_class
 
     def initialize(record, options = {})
-      @record   = record
-      @scope    = options[:scope]
-      @column   = (options[:column] || :sequential_id).to_sym
-      @start_at = options[:start_at] || 1
-      @skip     = options[:skip]
+      @record             = record
+      @scope              = options[:scope]
+      @column             = (options[:column] || :sequential_id).to_sym
+      @start_at           = options[:start_at] || 1
+      @skip               = options[:skip]
+      @use_sti_base_class = options[:use_sti_base_class] || false
     end
 
     def set
       unless id_set? || skip?
         where_opts = {
-          model:  record.class.name,
+          model:  use_sti_base_class ? record.class.base_class.name : record.class.name,
           column: column
         }
 

--- a/test/dummy/app/models/administrator.rb
+++ b/test/dummy/app/models/administrator.rb
@@ -1,0 +1,2 @@
+class Administrator < User
+end

--- a/test/dummy/app/models/author.rb
+++ b/test/dummy/app/models/author.rb
@@ -1,0 +1,2 @@
+class Author < User
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ActiveRecord::Base
+  sequential column: :user_number, use_sti_base_class: true
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131126174222) do
+ActiveRecord::Schema.define(version: 20141128230544) do
 
   create_table "comments", force: true do |t|
     t.string   "title"
@@ -57,6 +57,14 @@ ActiveRecord::Schema.define(version: 20131126174222) do
     t.integer  "story_number"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "users", force: true do |t|
+    t.string  "name"
+    t.string  "email"
+    t.string  "password_hash"
+    t.string  "type"
+    t.integer "user_number"
   end
 
 end

--- a/test/sequential_include_test.rb
+++ b/test/sequential_include_test.rb
@@ -74,4 +74,10 @@ class SequentialIncludeTest < ActiveSupport::TestCase
     assert_equal 1, c.sequential_id
   end
 
+  test 'use sti base class' do
+    admin = Administrator.create
+    author = Author.create
+    assert_equal 1, admin.user_number
+    assert_equal 2, author.user_number
+  end
 end


### PR DESCRIPTION
This may be a very special case feature. But I don't think it clutters the code too much even if it is rarely used.
The idea is that if you're using STI, sometimes that's really an implementation detail and you don't want to have that reflected in your publicly facing IDs.
So if you pass this option, the generator use the row in the sequential table for the AR base class of the record.
